### PR TITLE
fix bugs for "length > 1 in coercion to logical"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DOSE
 Type: Package
 Title: Disease Ontology Semantic and Enrichment analysis
-Version: 3.13.1
+Version: 3.13.2
 Authors@R: c( person(given = "Guangchuang", family = "Yu",        email = "guangchuangyu@gmail.com",   role = c("aut", "cre")),
               person(given = "Li-Gen",      family = "Wang",      email = "reeganwang020@gmail.com",   role = "ctb"),
               person(given = "Vladislav",   family = "Petyuk",    email = "petyuk@gmail.com",          role = "ctb"),

--- a/R/enricher_internal.R
+++ b/R/enricher_internal.R
@@ -227,7 +227,8 @@ TERMID2EXTID <- function(term, USER_DATA) {
 
 TERM2NAME <- function(term, USER_DATA) {
     PATHID2NAME <- get("PATHID2NAME", envir = USER_DATA)
-    if (is.null(PATHID2NAME) || is.na(PATHID2NAME)) {
+    #if (is.null(PATHID2NAME) || is.na(PATHID2NAME)) {
+    if (is.null(PATHID2NAME) || all(is.na(PATHID2NAME))) {
         return(as.character(term))
     }
     return(PATHID2NAME[term])

--- a/tests/testthat/test-doSim.R
+++ b/tests/testthat/test-doSim.R
@@ -4,5 +4,5 @@ context("doSim")
 
 test_that("doSim", {
     res <- sapply(c("Wang", "Lin", "Jiang", "Resnik", "Rel"), function(mm) doSim("DOID:1002", "DOID:10003", measure=mm))
-    expect_true(res >= 0 && res <= 1)
+    expect_true(all(res >= 0) && all(res <= 1))
 })

--- a/tests/testthat/test-geneSim.R
+++ b/tests/testthat/test-geneSim.R
@@ -4,6 +4,6 @@ context("geneSim")
 
 test_that("geneSim", {
     res <-  sapply(c("Wang", "Lin", "Jiang", "Resnik", "Rel"), function(mm) geneSim('2524', '3070', measure=mm))
-    expect_true(res >=0 && res <=1)
+    expect_true(all(res >=0) && all(res <=1))
 })
 


### PR DESCRIPTION
出现这个问题是因为enricher_internal.R 中的`TERM2NAME()`有个is.na(PATHID2NAME)，如果PATHID2NAME不是NA的话，它就会返回很多个FALSE。
类似的，testthat中的res >=0 也是会返回多个logical值。
把这些更改后，check通过了。