### PR TITLE
This fixes a bug where ... aren't passed to fgsea

### DIFF
--- a/R/gsea.R
+++ b/R/gsea.R
@@ -28,7 +28,8 @@ GSEA_fgsea <- function(geneList,
                          maxSize=maxGSSize,
                          eps=eps,
                          gseaParam=exponent,
-                         nproc = 0)
+                         nproc = 0
+                         ...)
     } else {
         warning("We do not recommend using nPerm parameter in",
                 "current and future releases")
@@ -38,7 +39,8 @@ GSEA_fgsea <- function(geneList,
                          minSize=minGSSize,
                          maxSize=maxGSSize,
                          gseaParam=exponent,
-                         nproc = 0)
+                         nproc = 0
+                         ...)
 
     }
 

--- a/R/gsea.R
+++ b/R/gsea.R
@@ -9,7 +9,8 @@ GSEA_fgsea <- function(geneList,
                        pAdjustMethod,
                        verbose,
                        seed=FALSE,
-                       USER_DATA) {
+                       USER_DATA,
+                       ...) {
 
     if(verbose)
         message("preparing geneSet collections...")

--- a/R/gsea.R
+++ b/R/gsea.R
@@ -28,7 +28,7 @@ GSEA_fgsea <- function(geneList,
                          maxSize=maxGSSize,
                          eps=eps,
                          gseaParam=exponent,
-                         nproc = 0
+                         nproc = 0,
                          ...)
     } else {
         warning("We do not recommend using nPerm parameter in",
@@ -39,7 +39,7 @@ GSEA_fgsea <- function(geneList,
                          minSize=minGSSize,
                          maxSize=maxGSSize,
                          gseaParam=exponent,
-                         nproc = 0
+                         nproc = 0,
                          ...)
 
     }


### PR DESCRIPTION
It is currently not possible to pass extra arguments to `fgsea`, in particular the `scoreType` argument, that now throws (R 4.0.2) a warning when not set properly. This PR fixes this.