### PR TITLE
update error message of `enricher_internal`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DOSE
 Type: Package
 Title: Disease Ontology Semantic and Enrichment analysis
-Version: 3.19.3
+Version: 3.19.3.991
 Authors@R: c( person(given = "Guangchuang", family = "Yu",        email = "guangchuangyu@gmail.com",   role = c("aut", "cre")),
               person(given = "Li-Gen",      family = "Wang",      email = "reeganwang020@gmail.com",   role = "ctb"),
               person(given = "Vladislav",   family = "Petyuk",    email = "petyuk@gmail.com",          role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# DOSE 3.19.3.991
+
++ upate error message of `enricher_internal` (2021-9-3, Fri)
+
 # DOSE 3.19.3
 
 + upate DisGeNET and NCG data (2021-8-16, Mon)

--- a/R/enricher_internal.R
+++ b/R/enricher_internal.R
@@ -78,7 +78,7 @@ enricher_internal <- function(gene,
     idx <- get_geneSet_index(termID2ExtID, minGSSize, maxGSSize)
 
     if (sum(idx) == 0) {
-        msg <- paste("No gene set have size between", minGSSize, "and", maxGSSize, "...")
+        msg <- paste("No gene sets have size between", minGSSize, "and", maxGSSize, "...")
         message(msg)
         message("--> return NULL...")
         return (NULL)

--- a/R/enricher_internal.R
+++ b/R/enricher_internal.R
@@ -78,7 +78,7 @@ enricher_internal <- function(gene,
     idx <- get_geneSet_index(termID2ExtID, minGSSize, maxGSSize)
 
     if (sum(idx) == 0) {
-        msg <- paste("No gene set have size >", minGSSize, "...")
+        msg <- paste("No gene set have size between", minGSSize, "and", maxGSSize, "...")
         message(msg)
         message("--> return NULL...")
         return (NULL)


### PR DESCRIPTION
当https://github.com/YuLab-SMU/DOSE/blob/master/R/enricher_internal.R#L80 中sum(idx) = 0时并不一定是所有的基因集大小都小于`minGSSize`，也有可能是所有的基因集大小都大于`maxGSSize`。 如https://github.com/YuLab-SMU/clusterProfiler/issues/365 这里用户所有基因集都大于700，但报错显示所有基因集都小于10，使用户产生误解。