### PR TITLE
Sort decreasing only for DOSE YuLab-SMU/DOSE#58

### DIFF
--- a/R/gsea.R
+++ b/R/gsea.R
@@ -162,8 +162,10 @@ GSEA_internal <- function(geneList,
                  ...) {
 
     by <- match.arg(by, c("fgsea", "DOSE"))
-    if (!is.sorted(geneList))
+    
+    if (all(!is.sorted(geneList), by == "DOSE")){
         stop("geneList should be a decreasing sorted vector...")
+    }
     if (by == 'fgsea') {
         .GSEA <- GSEA_fgsea
     } else {

--- a/R/gsea.R
+++ b/R/gsea.R
@@ -163,13 +163,14 @@ GSEA_internal <- function(geneList,
 
     by <- match.arg(by, c("fgsea", "DOSE"))
     
+ 
+  if (by == "fgsea") {
     .GSEA <- GSEA_fgsea
-    if (by == 'DOSE') {
-      if (!is.sorted(geneList)){
-        stop("geneList should be a decreasing sorted vector...")
-      }  
-      .GSEA <- GSEA_DOSE
-    } 
+  }
+  else {
+        if (!is.sorted(geneList)) stop("geneList should be a decreasing sorted vector...")
+    .GSEA <- GSEA_DOSE
+  }
       
 
    

--- a/R/gsea.R
+++ b/R/gsea.R
@@ -163,14 +163,15 @@ GSEA_internal <- function(geneList,
 
     by <- match.arg(by, c("fgsea", "DOSE"))
     
-    if (all(!is.sorted(geneList), by == "DOSE")){
+    .GSEA <- GSEA_fgsea
+    if (by == 'DOSE') {
+      if (!is.sorted(geneList)){
         stop("geneList should be a decreasing sorted vector...")
-    }
-    if (by == 'fgsea') {
-        .GSEA <- GSEA_fgsea
-    } else {
-        .GSEA <- GSEA_DOSE
-    }
+      }  
+      .GSEA <- GSEA_DOSE
+    } 
+      
+
    
     res <- .GSEA(geneList          = geneList,
                  exponent          = exponent,


### PR DESCRIPTION
Hi,

This removes the need for a decreasing only sort if not using `DOSE`. In `is.sorted` decreasing was set to `TRUE` which also affected `fgsea`.

Thank you,
NelsonGon