### PR TITLE
added keyoutput parameter to setReadable and modified EXTID2NAME func…

### DIFF
--- a/R/setReadable.R
+++ b/R/setReadable.R
@@ -1,17 +1,20 @@
-##' mapping geneID to gene Symbol
+##' mapping geneID to gene Symbol:
 ##'
 ##'
 ##' @title setReadable
 ##' @param x enrichResult Object
 ##' @param OrgDb OrgDb
 ##' @param keyType keyType of gene
+##' @param keyType keyType of symbol/gene name
 ##' @return enrichResult Object
 ##' @author Yu Guangchuang
 ##' @export
-setReadable <- function(x, OrgDb, keyType="auto") {
+
+# Added keyoutput = 'SYMBOL' as an optional parameter so it accepts other OrgDB columns as output
+setReadable <- function(x, OrgDb, keyType="auto", keyoutput = 'SYMBOL') {
     OrgDb <- load_OrgDb(OrgDb)
-    if (!'SYMBOL' %in% columns(OrgDb)) {
-        warning("Fail to convert input geneID to SYMBOL since no SYMBOL information available in the provided OrgDb...")
+    if (! keyoutput %in% columns(OrgDb)) {
+        warning(paste0("Fail to convert input geneID to SYMBOL since no ", keyoutput ," information available in the provided OrgDb..."))
     }
 
     if (!(is(x, "enrichResult") || is(x, "groupGOResult") || is(x, "gseaResult") || is(x,"compareClusterResult")))
@@ -50,7 +53,8 @@ setReadable <- function(x, OrgDb, keyType="auto") {
         genes <- x@gene
     }
 
-    gn <- EXTID2NAME(OrgDb, genes, keyType)
+    # Added keyoutput as an additional parameter in EXTID2NAME function.
+    gn <- EXTID2NAME(OrgDb, genes, keyType, keyoutput)
 
 
     if(isCompare) {

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -289,6 +289,7 @@ rebuildAnnoData.internal <- function(eg.do) {
 ##' @param OrgDb OrgDb
 ##' @param geneID entrez gene ID
 ##' @param keytype keytype
+##' @param keyoutput keytype
 ##' @return gene symbol
 ##' @importMethodsFrom AnnotationDbi select
 ##' @importMethodsFrom AnnotationDbi keys
@@ -297,14 +298,21 @@ rebuildAnnoData.internal <- function(eg.do) {
 ##' @importFrom GOSemSim load_OrgDb
 ##' @export
 ##' @author Guangchuang Yu \url{http://guangchuangyu.github.io}
-EXTID2NAME <- function(OrgDb, geneID, keytype) {
+EXTID2NAME <- function(OrgDb, geneID, keytype, keyoutput = "SYMBOL") {
+    # Added keyoutput = "SYMBOL" as a parameter so it is possible to define other columns as output
+    my_db <- OrgDb
     OrgDb <- load_OrgDb(OrgDb)
     kt <- keytypes(OrgDb)
     if (! keytype %in% kt) {
         stop("keytype is not supported...")
     }
+    
+    if (! keyoutput %in% columns(OrgDb)) {
+        stop(paste0("keyoutput ", keyoutput ," is not supported in db ", my_db))
+    }     
 
-    gn.df <- suppressMessages(select(OrgDb, keys=geneID, keytype=keytype, columns="SYMBOL"))
+    # I replaced columns="SYMBOL" with columns=keyoutput
+    gn.df <- suppressMessages(select(OrgDb, keys=geneID, keytype=keytype, columns=keyoutput))
     gn.df <- unique(gn.df)
     colnames(gn.df) <- c("GeneID", "SYMBOL")
 


### PR DESCRIPTION
I have edited setReadable and EXTID2NAME functions so they now they accept an additional parameter, "keyoutput", to call an alternative OrgDb output column holding gene names/symbols rather than enforcing the use of 'SYMBOL' as the only option. 
This change was necessary given that other OrgDb databases such as yeast's org.Sc.sgd.db store gene names/symbols under the GENENAME column and lack a SYMBOL column, giving an error message when using enrichGO and groupGO functions from ClusterProfiler package or setReadable function from this package.